### PR TITLE
Allow 128 characters in header key

### DIFF
--- a/deployment/config-static.js
+++ b/deployment/config-static.js
@@ -42,7 +42,7 @@ module.exports = {
 								key: {
 									type: 'string',
 									minLength: 1,
-									maxLength: 32,
+									maxLength: 128,
 									pattern: "^[a-zA-Z0-9_!#$%&'*+.^`|~-]+$"
 								},
 								value: {


### PR DESCRIPTION
Following up https://github.com/zeit/serve-handler/issues/61, we need space for longer headers. This number was suggested by @rauchg and I think it's fine.