### PR TITLE
Add importFlowGitProvider to the User schema

### DIFF
--- a/test/user.js
+++ b/test/user.js
@@ -168,3 +168,33 @@ exports.test_platformVersion_three_invalid = () => {
 	});
 	assert.equal(isValid, false);
 };
+
+exports.test_importFlowGitProvider_github_valid = () => {
+	assert(ajv.validate(User, {importFlowGitProvider: 'github'}));
+};
+
+exports.test_importFlowGitProvider_gitlab_valid = () => {
+	assert(ajv.validate(User, {importFlowGitProvider: 'gitlab'}));
+};
+
+exports.test_importFlowGitProvider_bitbucket_valid = () => {
+	assert(ajv.validate(User, {importFlowGitProvider: 'bitbucket'}));
+};
+
+exports.test_importFlowGitProvider_null_valid = () => {
+	assert(ajv.validate(User, {importFlowGitProvider: null}));
+};
+
+exports.test_importFlowGitProvider_invalid_value = () => {
+	const isValid = ajv.validate(User, {
+		importFlowGitProvider: 'test'
+	});
+	assert.equal(isValid, false);
+};
+
+exports.test_importFlowGitProvider_number_invalid = () => {
+	const isValid = ajv.validate(User, {
+		importFlowGitProvider: 10
+	});
+	assert.equal(isValid, false);
+};

--- a/user/index.js
+++ b/user/index.js
@@ -17,6 +17,18 @@ const Email = {
 	maxLength: 256
 };
 
+const ImportFlowGitProvider = {
+	oneOf: [
+		{
+			'enum': ['github', 'gitlab', 'bitbucket']
+		},
+		{
+			type: 'null'
+		}
+	]
+};
+
+
 const PlatformVersion = {
 	oneOf: [
 		{
@@ -82,7 +94,8 @@ const User = {
 		platformVersion: PlatformVersion,
 		bio: Bio,
 		website: Website,
-		profiles: Profiles
+		profiles: Profiles,
+		importFlowGitProvider: ImportFlowGitProvider
 	}
 };
 
@@ -92,5 +105,6 @@ module.exports = {
 	Name,
 	Email,
 	Avatar,
-	PlatformVersion
+	PlatformVersion,
+	ImportFlowGitProvider
 };


### PR DESCRIPTION
This PR adds the field `importFlowGitProvider` to the `User` schema. The new field will be used in the new import flow.

https://app.clubhouse.io/vercel/story/4314/create-endpoint-to-edit-preferred-git-connection-used-for-import-flow-suggestions-search