### PR TITLE
Add importFlowGitNamespace for user

### DIFF
--- a/test/user.js
+++ b/test/user.js
@@ -198,3 +198,26 @@ exports.test_importFlowGitProvider_number_invalid = () => {
 	});
 	assert.equal(isValid, false);
 };
+
+
+exports.test_importFlowGitNamespace_string_valid = () => {
+	assert(ajv.validate(User, {importFlowGitNamespace: 'test'}));
+};
+
+exports.test_importFlowGitNamespace_null_valid = () => {
+	assert(ajv.validate(User, {importFlowGitNamespace: null}));
+};
+
+exports.test_importFlowGitNamespace_number_invalid = () => {
+	const isValid = ajv.validate(User, {
+		importFlowGitNamespace: 10
+	});
+	assert.strictEqual(isValid, false);
+};
+
+exports.test_importFlowGitNamespace_boolean_invalid = () => {
+	const isValid = ajv.validate(User, {
+		importFlowGitNamespace: true
+	});
+	assert.strictEqual(isValid, false);
+};

--- a/user/index.js
+++ b/user/index.js
@@ -28,6 +28,16 @@ const ImportFlowGitProvider = {
 	]
 };
 
+const ImportFlowGitNamespace = {
+	oneOf: [
+		{
+			type: 'string'
+		},
+		{
+			type: 'null'
+		}
+	]
+};
 
 const PlatformVersion = {
 	oneOf: [
@@ -95,7 +105,8 @@ const User = {
 		bio: Bio,
 		website: Website,
 		profiles: Profiles,
-		importFlowGitProvider: ImportFlowGitProvider
+		importFlowGitProvider: ImportFlowGitProvider,
+		importFlowGitNamespace: ImportFlowGitNamespace
 	}
 };
 
@@ -106,5 +117,6 @@ module.exports = {
 	Email,
 	Avatar,
 	PlatformVersion,
-	ImportFlowGitProvider
+	ImportFlowGitProvider,
+	ImportFlowGitNamespace
 };


### PR DESCRIPTION
https://app.clubhouse.io/vercel/story/12414/add-importflowgitnamespace-attribute-to-user-documents

This PR adds a new field on the User's schema which we will use to store the preferred Git Namespace in the Import Flow.