### PR TITLE
Add scopeId and gitNamespaceId to the User schema

### DIFF
--- a/test/user.js
+++ b/test/user.js
@@ -241,3 +241,33 @@ exports.test_importFlowGitNamespaceId_boolean_invalid = () => {
 	assert.strictEqual(isValid, false);
 };
 
+exports.test_scopeId_valid = () => {
+	assert(ajv.validate(User, {scopeId: '123test'}));
+};
+
+exports.test_scopeId_invalid = () => {
+	const isValid = ajv.validate(User, {
+		scopeId: null
+	});
+	assert.strictEqual(isValid, false);
+};
+
+exports.test_gitNamespaceId_string_valid = () => {
+	assert(ajv.validate(User, {gitNamespaceId: 'test'}));
+};
+
+exports.test_gitNamespaceId_number_valid = () => {
+	assert(ajv.validate(User, {gitNamespaceId: 123}));
+};
+
+exports.test_gitNamespaceId_null_valid = () => {
+	assert(ajv.validate(User, {gitNamespaceId: null}));
+};
+
+exports.test_gitNamespaceId_boolean_invalid = () => {
+	const isValid = ajv.validate(User, {
+		gitNamespaceId: true
+	});
+	assert.strictEqual(isValid, false);
+};
+

--- a/user/index.js
+++ b/user/index.js
@@ -53,6 +53,24 @@ const ImportFlowGitNamespaceId = {
 	]
 };
 
+const ScopeId = {
+	type: 'string'
+};
+
+const GitNamespaceId = {
+	oneOf: [
+		{
+			type: 'string'
+		},
+		{
+			type: 'number'
+		},
+		{
+			type: 'null'
+		}
+	]
+};
+
 const PlatformVersion = {
 	oneOf: [
 		{
@@ -121,7 +139,9 @@ const User = {
 		profiles: Profiles,
 		importFlowGitProvider: ImportFlowGitProvider,
 		importFlowGitNamespace: ImportFlowGitNamespace,
-		importFlowGitNamespaceId: ImportFlowGitNamespaceId
+		importFlowGitNamespaceId: ImportFlowGitNamespaceId,
+		scopeId: ScopeId,
+		gitNamespaceId: GitNamespaceId
 	}
 };
 
@@ -134,5 +154,7 @@ module.exports = {
 	PlatformVersion,
 	ImportFlowGitProvider,
 	ImportFlowGitNamespace,
-	ImportFlowGitNamespaceId
+	ImportFlowGitNamespaceId,
+	ScopeId,
+	GitNamespaceId
 };


### PR DESCRIPTION
This PR adds two new fields to the User schema, `scopeId` and `gitNamespaceId`, which are going to be used to store a mapping between a Vercel scope and a Git namespace.