### PR TITLE
Add ViewPreference to schema

### DIFF
--- a/test/user.js
+++ b/test/user.js
@@ -294,6 +294,32 @@ exports.test_gitNamespaceId_boolean_invalid = () => {
 	assert.strictEqual(isValid, false);
 };
 
+exports.test_viewPreference_cards_valid = () => {
+	assert(ajv.validate(User, { viewPreference: 'cards' }));
+};
+
+exports.test_viewPreference_list_valid = () => {
+	assert(ajv.validate(User, { viewPreference: 'list' }));
+};
+
+exports.test_viewPreference_null_valid = () => {
+	assert(ajv.validate(User, { viewPreference: null }));
+};
+
+exports.test_viewPreference_invalid_value = () => {
+	const isValid = ajv.validate(User, {
+		viewPreference: 'test'
+	});
+	assert.equal(isValid, false);
+};
+
+exports.test_viewPreference_number_invalid = () => {
+	const isValid = ajv.validate(User, {
+		viewPreference: 10
+	});
+	assert.equal(isValid, false);
+};
+
 exports.test_remoteCaching_valid = () => {
 	assert(ajv.validate(User, { remoteCaching: { enabled: true } }));
 };

--- a/user/index.js
+++ b/user/index.js
@@ -71,6 +71,17 @@ const GitNamespaceId = {
 	]
 };
 
+const viewPreference = {
+	oneOf: [
+		{
+			'enum': ['cards', 'list']
+		},
+		{
+			type: 'null'
+		}
+	]
+};
+
 const PlatformVersion = {
 	oneOf: [
 		{
@@ -166,6 +177,7 @@ const User = {
 		importFlowGitNamespaceId: ImportFlowGitNamespaceId,
 		scopeId: ScopeId,
 		gitNamespaceId: GitNamespaceId,
+		viewPreference: viewPreference,
 		remoteCaching: RemoteCaching,
 		dismissedToasts: DismissedToasts
 	}
@@ -183,5 +195,6 @@ module.exports = {
 	ImportFlowGitNamespaceId,
 	ScopeId,
 	GitNamespaceId,
+	ViewPreference,
 	DismissedToasts
 };


### PR DESCRIPTION
In order for new api tests to work
https://github.com/vercel/api/pull/13032
Related to adding a new user preference so the dashboard view preference gets stored