### PR TITLE
Add an additional flag for default-force setting for feedback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zeit/schemas",
-  "version": "2.27.0",
+  "version": "2.28.0",
   "description": "All schemas used for validation that are shared between our projects",
   "scripts": {
     "test": "yarn run lint && best --verbose",

--- a/user/index.js
+++ b/user/index.js
@@ -185,7 +185,14 @@ const DismissedToasts = {
 const EnablePreviewFeedback = {
 	oneOf: [
 		{
-			enum: ['on', 'off', 'default', 'on-force', 'off-force'],
+			enum: [
+				'on',
+				'off',
+				'default',
+				'on-force',
+				'off-force',
+				'default-force',
+			],
 		},
 		{
 			type: 'null',


### PR DESCRIPTION
The UI at the team level has three settings and a toggle for allowing projects to override or not.

The previous change here added force-on and force-off, but didn't include a force default, which means that you can toggle the switch to off, but select default and after saving/refreshing the toggle would be changed again.  This change just adds the additional state.

<img width="318" alt="image" src="https://user-images.githubusercontent.com/4172067/191403701-10df5221-c3e5-4a98-a6c8-c8ae9451d6ac.png">
