### PR TITLE
Allow question marks (?) in HTTP header values

### DIFF
--- a/deployment/config-static.js
+++ b/deployment/config-static.js
@@ -49,7 +49,7 @@ module.exports = {
 									type: 'string',
 									minLength: 1,
 									maxLength: 2048,
-									pattern: "^[a-zA-Z0-9_!#$%&'*+.;/:, =^`|~-]+$"
+									pattern: "^[a-zA-Z0-9_!#$%&'*+.;/:, =^`|~?-]+$"
 								}
 							},
 							additionalProperties: false


### PR DESCRIPTION
The `report-uri` CSP directive can contain HTTP URLs which may contain a question mark, such as to pass query parameters. This is what [Sentry uses](https://docs.sentry.io/product/security-policy-reporting/) for instance.