### PR TITLE
Extend headers validation pattern

### DIFF
--- a/deployment/config-static.js
+++ b/deployment/config-static.js
@@ -49,7 +49,7 @@ module.exports = {
 									type: 'string',
 									minLength: 1,
 									maxLength: 2048,
-									pattern: "^[a-zA-Z0-9_!#$%&'*+.;/:, =^`|~-]+$"
+									pattern: '^[\u0020-\u007e\u00a0-\u00ff]+$'
 								}
 							},
 							additionalProperties: false

--- a/test/deployment.js
+++ b/test/deployment.js
@@ -181,6 +181,28 @@ exports.test_valid_static_headers_object = () => {
 	});
 
 	assert.equal(isValid, true);
+
+	for (let i = 0x20; i <= 0xff; i++) {
+		if (i > 0x7e && i < 0xa0) {
+			continue;
+		}
+
+		const result = ajv.validate(deploymentConfigSchema, {
+			'static': {
+				headers: [
+					{
+						source: '/',
+						headers: [{
+							key: 'X-Test',
+							value: `value ${String.fromCharCode(i)}`
+						}]
+					}
+				]
+			}
+		});
+
+		assert.equal(result, true, `Failed to validate for char: 0x${i.toString(16)}`);
+	}
 };
 
 exports.test_invalid_static_headers_object = () => {
@@ -206,6 +228,27 @@ exports.test_invalid_static_headers_object = () => {
 	});
 
 	assert.equal(isValid, false);
+
+	// Use 256 to go above 0xff
+	for (let i = 0; i <= 256; i++) {
+		if ((i >= 0x20 && i <= 0x7e) || (i >= 0xa0 && i <= 0xff)) {
+			continue;
+		}
+
+		const result = ajv.validate(deploymentConfigSchema, {
+			'static': {
+				headers: {
+					source: '/',
+					headers: [{
+						key: 'X-Test',
+						value: `value ${String.fromCharCode(i)}`
+					}]
+				}
+			}
+		});
+
+		assert.equal(result, false, `Failed to error for char: 0x${i.toString(16)}`);
+	}
 };
 
 exports.test_valid_static_object_trailing_slash = () => {


### PR DESCRIPTION
- Updates the headers value pattern to support all visible characters from ISO-8859-1, since the current pattern is very restrictive (more information in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5-4))
- Adds tests for the above change

Note: The RFC recommends to use only visible US-ASCII octets as values for headers, however, I don't think we should fail the validation for what could be possible as it'll depend on the actual HTTP server to parse that data.