### PR TITLE
feat: add `defaultTeamId` to `User` schema

### DIFF
--- a/user/index.js
+++ b/user/index.js
@@ -227,44 +227,57 @@ const EnablePreviewFeedback = {
 	]
 };
 
+const DefaultTeamId = {
+  oneOf: [
+    {
+      type: 'string',
+      maxLength: 29,
+    },
+    {
+      type: 'null',
+    },
+  ],
+}
+
 const User = {
-	type: 'object',
-	additionalProperties: false,
-	properties: {
-		username: Username,
-		name: Name,
-		email: Email,
-		billingChecked: { type: 'boolean' },
-		avatar: Avatar,
-		platformVersion: PlatformVersion,
-		bio: Bio,
-		website: Website,
-		profiles: Profiles,
-		importFlowGitProvider: ImportFlowGitProvider,
-		importFlowGitNamespace: ImportFlowGitNamespace,
-		importFlowGitNamespaceId: ImportFlowGitNamespaceId,
-		scopeId: ScopeId,
-		gitNamespaceId: GitNamespaceId,
-		viewPreference: ViewPreference,
-		remoteCaching: RemoteCaching,
-		dismissedToasts: DismissedToasts,
-		enablePreviewFeedback: EnablePreviewFeedback,
-		favoriteProjectsAndSpaces: FavoriteProjectsAndSpaces
-	}
-};
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    username: Username,
+    name: Name,
+    email: Email,
+    billingChecked: { type: 'boolean' },
+    avatar: Avatar,
+    platformVersion: PlatformVersion,
+    bio: Bio,
+    website: Website,
+    profiles: Profiles,
+    importFlowGitProvider: ImportFlowGitProvider,
+    importFlowGitNamespace: ImportFlowGitNamespace,
+    importFlowGitNamespaceId: ImportFlowGitNamespaceId,
+    scopeId: ScopeId,
+    gitNamespaceId: GitNamespaceId,
+    viewPreference: ViewPreference,
+    remoteCaching: RemoteCaching,
+    dismissedToasts: DismissedToasts,
+    enablePreviewFeedback: EnablePreviewFeedback,
+    favoriteProjectsAndSpaces: FavoriteProjectsAndSpaces,
+    defaultTeamId: DefaultTeamId,
+  },
+}
 
 module.exports = {
-	User,
-	Username,
-	Name,
-	Email,
-	Avatar,
-	PlatformVersion,
-	ImportFlowGitProvider,
-	ImportFlowGitNamespace,
-	ImportFlowGitNamespaceId,
-	ScopeId,
-	GitNamespaceId,
-	ViewPreference,
-	DismissedToasts
-};
+  User,
+  Username,
+  Name,
+  Email,
+  Avatar,
+  PlatformVersion,
+  ImportFlowGitProvider,
+  ImportFlowGitNamespace,
+  ImportFlowGitNamespaceId,
+  ScopeId,
+  GitNamespaceId,
+  ViewPreference,
+  DismissedToasts,
+}

--- a/user/index.js
+++ b/user/index.js
@@ -228,56 +228,56 @@ const EnablePreviewFeedback = {
 };
 
 const DefaultTeamId = {
-  oneOf: [
-    {
-      type: 'string',
-      maxLength: 29,
-    },
-    {
-      type: 'null',
-    },
-  ],
-}
+	oneOf: [
+		{
+			type: 'string',
+			maxLength: 29
+		},
+		{
+			type: 'null'
+		}
+	]
+};
 
 const User = {
-  type: 'object',
-  additionalProperties: false,
-  properties: {
-    username: Username,
-    name: Name,
-    email: Email,
-    billingChecked: { type: 'boolean' },
-    avatar: Avatar,
-    platformVersion: PlatformVersion,
-    bio: Bio,
-    website: Website,
-    profiles: Profiles,
-    importFlowGitProvider: ImportFlowGitProvider,
-    importFlowGitNamespace: ImportFlowGitNamespace,
-    importFlowGitNamespaceId: ImportFlowGitNamespaceId,
-    scopeId: ScopeId,
-    gitNamespaceId: GitNamespaceId,
-    viewPreference: ViewPreference,
-    remoteCaching: RemoteCaching,
-    dismissedToasts: DismissedToasts,
-    enablePreviewFeedback: EnablePreviewFeedback,
-    favoriteProjectsAndSpaces: FavoriteProjectsAndSpaces,
-    defaultTeamId: DefaultTeamId,
-  },
-}
+	type: 'object',
+	additionalProperties: false,
+	properties: {
+		username: Username,
+		name: Name,
+		email: Email,
+		billingChecked: { type: 'boolean' },
+		avatar: Avatar,
+		platformVersion: PlatformVersion,
+		bio: Bio,
+		website: Website,
+		profiles: Profiles,
+		importFlowGitProvider: ImportFlowGitProvider,
+		importFlowGitNamespace: ImportFlowGitNamespace,
+		importFlowGitNamespaceId: ImportFlowGitNamespaceId,
+		scopeId: ScopeId,
+		gitNamespaceId: GitNamespaceId,
+		viewPreference: ViewPreference,
+		remoteCaching: RemoteCaching,
+		dismissedToasts: DismissedToasts,
+		enablePreviewFeedback: EnablePreviewFeedback,
+		favoriteProjectsAndSpaces: FavoriteProjectsAndSpaces,
+		defaultTeamId: DefaultTeamId
+	}
+};
 
 module.exports = {
-  User,
-  Username,
-  Name,
-  Email,
-  Avatar,
-  PlatformVersion,
-  ImportFlowGitProvider,
-  ImportFlowGitNamespace,
-  ImportFlowGitNamespaceId,
-  ScopeId,
-  GitNamespaceId,
-  ViewPreference,
-  DismissedToasts,
-}
+	User,
+	Username,
+	Name,
+	Email,
+	Avatar,
+	PlatformVersion,
+	ImportFlowGitProvider,
+	ImportFlowGitNamespace,
+	ImportFlowGitNamespaceId,
+	ScopeId,
+	GitNamespaceId,
+	ViewPreference,
+	DismissedToasts
+};


### PR DESCRIPTION
Extends `User` schema to enable the updating of a user's `defaultTeamId` via the `PATCH` user endpoint in `api`.