### PR TITLE
Bump version to `v2.32.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zeit/schemas",
-  "version": "2.31.0",
+  "version": "2.32.0",
   "description": "All schemas used for validation that are shared between our projects",
   "scripts": {
     "test": "yarn run lint && best --verbose",


### PR DESCRIPTION
Tracks changes made in https://github.com/vercel/schemas/pull/81 in order to publish to `npm`.