### PR TITLE
update username regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zeit/schemas",
-  "version": "2.36.0",
+  "version": "2.37.0",
   "description": "All schemas used for validation that are shared between our projects",
   "scripts": {
     "test": "yarn run lint && best --verbose",

--- a/test/user.js
+++ b/test/user.js
@@ -48,11 +48,10 @@ exports.test_username_too_short = () => {
 };
 
 exports.test_username_too_long = () => {
-	const isValid = ajv.validate(User, {
-		username: 'a'.repeat(50)
-	});
+	const username = 'a'.repeat(50);
+	const isValid = ajv.validate(User, { username });
 	assert.equal(isValid, false);
-	assert.equal(ajv.errors.length, 1);
+	assert.equal(ajv.errors.length, 2);
 	assert.equal(ajv.errors[0].dataPath, '.username');
 	assert.equal(
 		ajv.errors[0].message,

--- a/test/user.js
+++ b/test/user.js
@@ -68,6 +68,11 @@ exports.test_username_valid = () => {
 	assert(ajv.validate(User, { username: 'rauchg' }));
 };
 
+exports.test_username_one_char = () => {
+	assert(ajv.validate(User, { username: 'a' }));
+	assert(ajv.validate(User, { username: '1' }));
+};
+
 // Name
 exports.test_name_too_short = () => {
 	const isValid = ajv.validate(User, {

--- a/test/user.js
+++ b/test/user.js
@@ -25,7 +25,7 @@ exports.test_username_invalid_pattern = () => {
 	assert.equal(ajv.errors[0].dataPath, '.username');
 	assert.equal(
 		ajv.errors[0].message,
-		'should match pattern "^[a-z0-9][a-z0-9-]*[a-z0-9]$"'
+		'should match pattern "^(?!-)(?:[a-z0-9-]{1,48})(?<!-)$"'
 	);
 };
 
@@ -43,7 +43,7 @@ exports.test_username_too_short = () => {
 	assert.equal(ajv.errors[1].dataPath, '.username');
 	assert.equal(
 		ajv.errors[1].message,
-		'should match pattern "^[a-z0-9][a-z0-9-]*[a-z0-9]$"'
+		'should match pattern "^(?!-)(?:[a-z0-9-]{1,48})(?<!-)$"'
 	);
 };
 
@@ -57,6 +57,10 @@ exports.test_username_too_long = () => {
 	assert.equal(
 		ajv.errors[0].message,
 		'should NOT be longer than 48 characters'
+	);
+	assert.equal(
+		ajv.errors[1].message,
+		'should match pattern "^(?!-)(?:[a-z0-9-]{1,48})(?<!-)$"'
 	);
 };
 

--- a/user/index.js
+++ b/user/index.js
@@ -2,7 +2,7 @@ const Username = {
 	type: 'string',
 	minLength: 1,
 	maxLength: 48,
-	pattern: '^[a-z0-9][a-z0-9-]*[a-z0-9]$'
+	pattern: '^(?!-)(?:[a-z0-9-]{1,48})(?<!-)$'
 };
 
 const Name = {


### PR DESCRIPTION
This PR updates the Regex used to validate usernames.

The previous regex did not allow for single character usernames which the file and error message returned to the user said we did.

The previous regex also allowed for usernames that were longer than 48 characters